### PR TITLE
Updating default inline scanner image to v0.7.0

### DIFF
--- a/src/main/java/io/jenkins/plugins/laceworkscannerbuildstep/LaceworkScannerExecuter.java
+++ b/src/main/java/io/jenkins/plugins/laceworkscannerbuildstep/LaceworkScannerExecuter.java
@@ -36,7 +36,7 @@ public class LaceworkScannerExecuter {
             args.add("docker", "run");
 
             String inlineScannerRepo = "lacework/lacework-inline-scanner";
-            String inlineScannerTag = "0.2.13";
+            String inlineScannerTag = "0.7.0";
             if (env.get("LW_INLINE_SCANNER_VERSION") != null) {
                 inlineScannerTag = env.get("LW_INLINE_SCANNER_VERSION");
             }


### PR DESCRIPTION
Updating the default Lacework Inline Scanner image to the current latest build `v0.7.0`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue